### PR TITLE
Fixes bricks sprite renderer color bug.

### DIFF
--- a/Assets/Scripts/Systems/BrickSpawnerSystem.cs
+++ b/Assets/Scripts/Systems/BrickSpawnerSystem.cs
@@ -10,6 +10,7 @@ using Random = UnityEngine.Random;
 using Unity.Jobs;
 
 [AlwaysSynchronizeSystem]
+[UpdateBefore(typeof(SpriteRenderer))]
 public class BrickSpawnerSystem : JobComponentSystem
 {
     private List<Entity> createdBricks;


### PR DESCRIPTION
Changed the brick spawner job order before SpriteRender to make sure the updated SpriteRenderer is drawn in scene.

************

Problem was that brick spawner job was running after SpriteRender internal jobs. So, the update/change in the color filed of the brick SpriteRenderer wasn't updated in the scene.